### PR TITLE
Atualiza nome da pasta do projeto para 'ntask-web' na seção de instalação no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ E tem mais no [package.json](https://github.com/caio-ribeiro-pereira/ntask-web/b
 ## Instalação
 
 * Clone o repositório: `git clone git@github.com:caio-ribeiro-pereira/ntask-web.git`
-* Acesse o diretório do projeto: `cd ntask-api`
+* Acesse o diretório do projeto: `cd ntask-web`
 * Instale as dependências: `npm install`
 * Inicie o servidor: `npm start`
 * Rodar testes: `npm test`


### PR DESCRIPTION
O nome da pasta está como `ntask-api`. Corrigir para `ntask-web`.
